### PR TITLE
Refresh all pins, add ultralytics

### DIFF
--- a/runtime/environment.yml
+++ b/runtime/environment.yml
@@ -1,24 +1,31 @@
 name: spacecraftpose
 channels:
   - conda-forge
+  - pytorch
 dependencies:
-  - keras=2.13
-  - lightgbm=4.1
-  - loguru=0.7
-  - geopandas=0.14
-  - numba=0.58
-  - numpy=1.26
-  - pandas=2.1
-  - pip=23.3
-  - pydantic=1.10
-  - opencv
-  - pytest=7.4
-  - python=3.10
-  - pytorch=1.*=cpu*
-  - pytorch-lightning
-  - scikit-learn=1.3
-  - scipy=1.11
-  - statsmodels=0.14
-  - tensorflow=2.13.*=cpu*
-  - tqdm=4.66
-  - xgboost=1.7.*=cpu*
+  - albumentations=1.3.1
+  - fastai=2.7.14
+  - imageio=2.33.1
+  - keras=2.15.0
+  - lightgbm=4.3.0
+  - loguru=0.7.2
+  - numba=0.59.0
+  - numpy=1.26.4
+  - pandas=2.2.0
+  - pillow=10.2.0
+  - pip=24.0
+  - pydantic=2.6.1
+  - opencv=4.9.0
+  - pytest=8.0.0
+  - python=3.11.7
+  - pytorch-cpu=2.1.0
+  - pytorch-lightning=2.1.3
+  - scikit-image=0.22.0
+  - scikit-learn=1.4.0
+  - scipy=1.12.0
+  - statsmodels=0.14.1
+  - tensorflow=2.15.0
+  - torchvision=0.16.1
+  - ultralytics=8.1.10
+  - tqdm=4.66.1
+  - xgboost=2.0.3


### PR DESCRIPTION
Updates versions, adds some standard CV packages, including `ultralytics` which is required for object detection benchmark.

@isms if you can prioritize review, it would be nice to get merged so I can use as the ACR public image.